### PR TITLE
A major update on generated project files and scaffolds

### DIFF
--- a/anvil.py
+++ b/anvil.py
@@ -6,7 +6,7 @@ import argparse
 
 import job_init
 
-VER = '0.6.1'
+VER = '0.7.0'
 
 
 def show_anvil_version(_):

--- a/job_init.py
+++ b/job_init.py
@@ -28,6 +28,7 @@ if({cap_name}_NOT_SUBPROJECT)
   set(CMAKE_CXX_STANDARD {cxx_standard})
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
   set(ROOT_DIR ${{CMAKE_SOURCE_DIR}})
 endif()
@@ -78,7 +79,7 @@ _COMPILER_POSIX_TEMPLATE = \
 
 _CLANG_TIDY_TEMPLATE = \
     '''include(${{{cap_name}_CMAKE_DIR}}/clang_tidy.cmake)
-    '''
+'''
 
 _ADD_MAIN_MODULE_TEMPLATE = 'add_subdirectory({name})\n'
 
@@ -105,7 +106,11 @@ target_link_libraries({name}
 {low_proj_name}_apply_common_compile_options({name})
 '''
 
-_MAIN_OPTIONS_TEMPLATE = '''# TODO: Edit at your will
+_MAIN_OPTIONS_TEMPLATE = '''if({cap_proj_name}_ENABLE_CLANG_TIDY)
+  {low_proj_name}_apply_clang_tidy({name})
+endif()
+
+# TODO: Edit at your will
 if(MSVC)
   if({cap_proj_name}_USE_MSVC_PARALLEL_BUILD)
     {low_proj_name}_apply_msvc_parallel_build({name})
@@ -116,13 +121,14 @@ if(MSVC)
         /wd6011 # Dereferencing potentially NULL pointer.
     )
   endif()
-  get_target_property({name}_FILES {name} SOURCES)
-  source_group("{name}" FILES ${{{name}_FILES}})
 else()
   if({cap_proj_name}_USE_SANITIZER)
     {low_proj_name}_apply_sanitizer({name})
   endif()
 endif()
+
+get_target_property({name}_FILES {name} SOURCES)
+source_group(TREE ${{CMAKE_CURRENT_SOURCE_DIR}} FILES ${{{name}_FILES}})
 '''
 
 _MAIN_USE_PCH_TEMPLATE = '''target_precompile_headers({name}

--- a/scaffolds/.clang-tidy
+++ b/scaffolds/.clang-tidy
@@ -14,8 +14,10 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-vararg,
   -misc-no-recursion,
   -modernize-avoid-c-arrays,
@@ -29,8 +31,8 @@ Checks: >
   -readability-qualified-auto,
   -readability-redundant-access-specifiers
 
-WarningsAsErrors: ''
-HeaderFilterRegex: ''
+WarningsAsErrors: '*'
+HeaderFilterRegex: '(folder1|folder2)\/.*\.h$'
 
 CheckOptions:
   - key: cppcoreguidelines-macro-usage.CheckCapsOnly

--- a/scaffolds/build.py
+++ b/scaffolds/build.py
@@ -13,9 +13,24 @@ import platform
 import shutil
 import subprocess
 
-from distutils.util import strtobool
-
 OS_WIN = 'Windows'
+
+
+# `distuils` is deprecated and will be removed since 3.12. Let's retain the
+# function.
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
 
 
 def default_generator():
@@ -124,9 +139,6 @@ class multiconf_subsystem():
 
         if self._gen:
             cmd.append(f'-G "{self._gen}"')
-
-        if self._clang_tidy:
-            cmd.append('-D{PROJNAME}_ENABLE_CLANG_TIDY=ON')
 
         clang_tidy = 'ON' if self._clang_tidy else 'OFF'
         cmd.append(f'-D{PROJNAME}_ENABLE_CLANG_TIDY={clang_tidy}')

--- a/scaffolds/cmake_modules/CPM.cmake
+++ b/scaffolds/cmake_modules/CPM.cmake
@@ -28,10 +28,25 @@
 
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-set(CURRENT_CPM_VERSION 0.35.0)
+# Initialize logging prefix
+if(NOT CPM_INDENT)
+  set(CPM_INDENT
+      "CPM:"
+      CACHE INTERNAL ""
+  )
+endif()
 
+if(NOT COMMAND cpm_message)
+  function(cpm_message)
+    message(${ARGV})
+  endfunction()
+endif()
+
+set(CURRENT_CPM_VERSION 0.37.0)
+
+get_filename_component(CPM_CURRENT_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
 if(CPM_DIRECTORY)
-  if(NOT CPM_DIRECTORY STREQUAL CMAKE_CURRENT_LIST_DIR)
+  if(NOT CPM_DIRECTORY STREQUAL CPM_CURRENT_DIRECTORY)
     if(CPM_VERSION VERSION_LESS CURRENT_CPM_VERSION)
       message(
         AUTHOR_WARNING
@@ -58,13 +73,34 @@ See https://github.com/cpm-cmake/CPM.cmake for more information."
 endif()
 
 if(CURRENT_CPM_VERSION MATCHES "development-version")
-  message(WARNING "Your project is using an unstable development version of CPM.cmake. \
+  message(
+    WARNING "${CPM_INDENT} Your project is using an unstable development version of CPM.cmake. \
 Please update to a recent release if possible. \
 See https://github.com/cpm-cmake/CPM.cmake for details."
   )
 endif()
 
 set_property(GLOBAL PROPERTY CPM_INITIALIZED true)
+
+macro(cpm_set_policies)
+  # the policy allows us to change options without caching
+  cmake_policy(SET CMP0077 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+  # the policy allows us to change set(CACHE) without caching
+  if(POLICY CMP0126)
+    cmake_policy(SET CMP0126 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+  endif()
+
+  # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+  # allows for proper rebuilds when a projects url changes
+  if(POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+  endif()
+endmacro()
+cpm_set_policies()
 
 option(CPM_USE_LOCAL_PACKAGES "Always try to use `find_package` to get dependencies"
        $ENV{CPM_USE_LOCAL_PACKAGES}
@@ -93,7 +129,7 @@ set(CPM_VERSION
     CACHE INTERNAL ""
 )
 set(CPM_DIRECTORY
-    ${CMAKE_CURRENT_LIST_DIR}
+    ${CPM_CURRENT_DIRECTORY}
     CACHE INTERNAL ""
 )
 set(CPM_FILE
@@ -202,19 +238,14 @@ function(cpm_package_name_and_ver_from_url url outName outVer)
   endif()
 endfunction()
 
-# Initialize logging prefix
-if(NOT CPM_INDENT)
-  set(CPM_INDENT
-      "CPM:"
-      CACHE INTERNAL ""
-  )
-endif()
-
 function(cpm_find_package NAME VERSION)
   string(REPLACE " " ";" EXTRA_ARGS "${ARGN}")
   find_package(${NAME} ${VERSION} ${EXTRA_ARGS} QUIET)
   if(${CPM_ARGS_NAME}_FOUND)
-    message(STATUS "${CPM_INDENT} using local package ${CPM_ARGS_NAME}@${VERSION}")
+    if(DEFINED ${CPM_ARGS_NAME}_VERSION)
+      set(VERSION ${${CPM_ARGS_NAME}_VERSION})
+    endif()
+    cpm_message(STATUS "${CPM_INDENT} Using local package ${CPM_ARGS_NAME}@${VERSION}")
     CPMRegisterPackage(${CPM_ARGS_NAME} "${VERSION}")
     set(CPM_PACKAGE_FOUND
         YES
@@ -285,7 +316,7 @@ function(cpm_check_if_package_already_added CPM_ARGS_NAME CPM_ARGS_VERSION)
     if("${CPM_PACKAGE_VERSION}" VERSION_LESS "${CPM_ARGS_VERSION}")
       message(
         WARNING
-          "${CPM_INDENT} requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
+          "${CPM_INDENT} Requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
       )
     endif()
     cpm_get_fetch_properties(${CPM_ARGS_NAME})
@@ -342,7 +373,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
       set(packageType "git")
     else()
       # Give up
-      message(FATAL_ERROR "CPM: Can't determine package type of '${arg}'")
+      message(FATAL_ERROR "${CPM_INDENT} Can't determine package type of '${arg}'")
     endif()
   endif()
 
@@ -362,7 +393,7 @@ function(cpm_parse_add_package_single_arg arg outArgs)
   else()
     # We should never get here. This is an assertion and hitting it means there's a bug in the code
     # above. A packageType was set, but not handled by this if-else.
-    message(FATAL_ERROR "CPM: Unsupported package type '${packageType}' of '${arg}'")
+    message(FATAL_ERROR "${CPM_INDENT} Unsupported package type '${packageType}' of '${arg}'")
   endif()
 
   set(${outArgs}
@@ -395,7 +426,7 @@ function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
   )
   if(resultGitStatus)
     # not supposed to happen, assume clean anyway
-    message(WARNING "Calling git status on folder ${repoPath} failed")
+    message(WARNING "${CPM_INDENT} Calling git status on folder ${repoPath} failed")
     set(${isClean}
         TRUE
         PARENT_SCOPE
@@ -433,8 +464,51 @@ function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
 
 endfunction()
 
+# method to overwrite internal FetchContent properties, to allow using CPM.cmake to overload
+# FetchContent calls. As these are internal cmake properties, this method should be used carefully
+# and may need modification in future CMake versions. Source:
+# https://github.com/Kitware/CMake/blob/dc3d0b5a0a7d26d43d6cfeb511e224533b5d188f/Modules/FetchContent.cmake#L1152
+function(cpm_override_fetchcontent contentName)
+  cmake_parse_arguments(PARSE_ARGV 1 arg "" "SOURCE_DIR;BINARY_DIR" "")
+  if(NOT "${arg_UNPARSED_ARGUMENTS}" STREQUAL "")
+    message(FATAL_ERROR "${CPM_INDENT} Unsupported arguments: ${arg_UNPARSED_ARGUMENTS}")
+  endif()
+
+  string(TOLOWER ${contentName} contentNameLower)
+  set(prefix "_FetchContent_${contentNameLower}")
+
+  set(propertyName "${prefix}_sourceDir")
+  define_property(
+    GLOBAL
+    PROPERTY ${propertyName}
+    BRIEF_DOCS "Internal implementation detail of FetchContent_Populate()"
+    FULL_DOCS "Details used by FetchContent_Populate() for ${contentName}"
+  )
+  set_property(GLOBAL PROPERTY ${propertyName} "${arg_SOURCE_DIR}")
+
+  set(propertyName "${prefix}_binaryDir")
+  define_property(
+    GLOBAL
+    PROPERTY ${propertyName}
+    BRIEF_DOCS "Internal implementation detail of FetchContent_Populate()"
+    FULL_DOCS "Details used by FetchContent_Populate() for ${contentName}"
+  )
+  set_property(GLOBAL PROPERTY ${propertyName} "${arg_BINARY_DIR}")
+
+  set(propertyName "${prefix}_populated")
+  define_property(
+    GLOBAL
+    PROPERTY ${propertyName}
+    BRIEF_DOCS "Internal implementation detail of FetchContent_Populate()"
+    FULL_DOCS "Details used by FetchContent_Populate() for ${contentName}"
+  )
+  set_property(GLOBAL PROPERTY ${propertyName} TRUE)
+endfunction()
+
 # Download and add a package from source
 function(CPMAddPackage)
+  cpm_set_policies()
+
   list(LENGTH ARGN argnLength)
   if(argnLength EQUAL 1)
     cpm_parse_add_package_single_arg("${ARGN}" ARGN)
@@ -533,7 +607,7 @@ function(CPMAddPackage)
   if(NOT DEFINED CPM_ARGS_NAME)
     message(
       FATAL_ERROR
-        "CPM: 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
+        "${CPM_INDENT} 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
     )
   endif()
 
@@ -583,7 +657,7 @@ function(CPMAddPackage)
     if(CPM_LOCAL_PACKAGES_ONLY)
       message(
         SEND_ERROR
-          "CPM: ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
+          "${CPM_INDENT} ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
       )
     endif()
   endif()
@@ -609,6 +683,20 @@ function(CPMAddPackage)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS DOWNLOAD_COMMAND ${CPM_ARGS_DOWNLOAD_COMMAND})
   elseif(DEFINED CPM_ARGS_SOURCE_DIR)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${CPM_ARGS_SOURCE_DIR})
+    if(NOT IS_ABSOLUTE ${CPM_ARGS_SOURCE_DIR})
+      # Expand `CPM_ARGS_SOURCE_DIR` relative path. This is important because EXISTS doesn't work
+      # for relative paths.
+      get_filename_component(
+        source_directory ${CPM_ARGS_SOURCE_DIR} REALPATH BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}
+      )
+    else()
+      set(source_directory ${CPM_ARGS_SOURCE_DIR})
+    endif()
+    if(NOT EXISTS ${source_directory})
+      string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
+      # remove timestamps so CMake will re-download the dependency
+      file(REMOVE_RECURSE "${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-subbuild")
+    endif()
   elseif(CPM_SOURCE_CACHE AND NOT CPM_ARGS_NO_CACHE)
     string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
     set(origin_parameters ${CPM_ARGS_UNPARSED_ARGUMENTS})
@@ -624,6 +712,9 @@ function(CPMAddPackage)
     # relative paths.
     get_filename_component(download_directory ${download_directory} ABSOLUTE)
     list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${download_directory})
+
+    file(LOCK ${download_directory}/../cmake.lock)
+
     if(EXISTS ${download_directory})
       cpm_store_fetch_properties(
         ${CPM_ARGS_NAME} "${download_directory}"
@@ -631,11 +722,13 @@ function(CPMAddPackage)
       )
       cpm_get_fetch_properties("${CPM_ARGS_NAME}")
 
-      if(DEFINED CPM_ARGS_GIT_TAG)
+      if(DEFINED CPM_ARGS_GIT_TAG AND NOT (PATCH_COMMAND IN_LIST CPM_ARGS_UNPARSED_ARGUMENTS))
         # warn if cache has been changed since checkout
         cpm_check_git_working_dir_is_clean(${download_directory} ${CPM_ARGS_GIT_TAG} IS_CLEAN)
         if(NOT ${IS_CLEAN})
-          message(WARNING "Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty")
+          message(
+            WARNING "${CPM_INDENT} Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty"
+          )
         endif()
       endif()
 
@@ -644,8 +737,15 @@ function(CPMAddPackage)
         "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
         "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
       )
-      set(CPM_SKIP_FETCH TRUE)
       set(PACKAGE_INFO "${PACKAGE_INFO} at ${download_directory}")
+
+      # As the source dir is already cached/populated, we override the call to FetchContent.
+      set(CPM_SKIP_FETCH TRUE)
+      cpm_override_fetchcontent(
+        "${lower_case_name}" SOURCE_DIR "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}"
+        BINARY_DIR "${${CPM_ARGS_NAME}_BINARY_DIR}"
+      )
+
     else()
       # Enable shallow clone when GIT_TAG is not a commit hash. Our guess may not be accurate, but
       # it should guarantee no commit hash get mis-detected.
@@ -674,8 +774,8 @@ function(CPMAddPackage)
     endif()
   endif()
 
-  message(
-    STATUS "${CPM_INDENT} adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
+  cpm_message(
+    STATUS "${CPM_INDENT} Adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
   )
 
   if(NOT CPM_SKIP_FETCH)
@@ -693,6 +793,10 @@ function(CPMAddPackage)
     cpm_get_fetch_properties("${CPM_ARGS_NAME}")
   endif()
 
+  if(EXISTS ${download_directory}/../cmake.lock)
+    file(LOCK ${download_directory}/../cmake.lock RELEASE)
+  endif()
+
   set(${CPM_ARGS_NAME}_ADDED YES)
   cpm_export_variables("${CPM_ARGS_NAME}")
 endfunction()
@@ -702,7 +806,7 @@ macro(CPMGetPackage Name)
   if(DEFINED "CPM_DECLARATION_${Name}")
     CPMAddPackage(NAME ${Name})
   else()
-    message(SEND_ERROR "Cannot retrieve package ${Name}: no declaration available")
+    message(SEND_ERROR "${CPM_INDENT} Cannot retrieve package ${Name}: no declaration available")
   endif()
 endmacro()
 
@@ -718,6 +822,10 @@ macro(cpm_export_variables name)
   )
   set(${name}_ADDED
       "${${name}_ADDED}"
+      PARENT_SCOPE
+  )
+  set(CPM_LAST_PACKAGE_NAME
+      "${name}"
       PARENT_SCOPE
   )
 endmacro()
@@ -788,7 +896,7 @@ endfunction()
 # declares a package in FetchContent_Declare
 function(cpm_declare_fetch PACKAGE VERSION INFO)
   if(${CPM_DRY_RUN})
-    message(STATUS "${CPM_INDENT} package not declared (dry run)")
+    cpm_message(STATUS "${CPM_INDENT} Package not declared (dry run)")
     return()
   endif()
 
@@ -843,16 +951,6 @@ function(
       set(addSubdirectoryExtraArgs "")
     endif()
     if(OPTIONS)
-      # the policy allows us to change options without caching
-      cmake_policy(SET CMP0077 NEW)
-      set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-
-      # the policy allows us to change set(CACHE) without caching
-      if(POLICY CMP0126)
-        cmake_policy(SET CMP0126 NEW)
-        set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
-      endif()
-
       foreach(OPTION ${OPTIONS})
         cpm_parse_option("${OPTION}")
         set(${OPTION_KEY} "${OPTION_VALUE}")
@@ -873,7 +971,7 @@ function(cpm_fetch_package PACKAGE populated)
       PARENT_SCOPE
   )
   if(${CPM_DRY_RUN})
-    message(STATUS "${CPM_INDENT} package ${PACKAGE} not fetched (dry run)")
+    cpm_message(STATUS "${CPM_INDENT} Package ${PACKAGE} not fetched (dry run)")
     return()
   endif()
 

--- a/scaffolds/cmake_modules/clang_tidy.cmake
+++ b/scaffolds/cmake_modules/clang_tidy.cmake
@@ -1,18 +1,31 @@
 
 option({PROJNAME}_ENABLE_CLANG_TIDY "Enable clang-tidy on build" OFF)
+message(STATUS "{PROJNAME}_ENABLE_CLANG_TIDY = ${{PROJNAME}_ENABLE_CLANG_TIDY}")
 
 if({PROJNAME}_ENABLE_CLANG_TIDY)
   find_program(CLANG_TIDY_EXE
                NAMES clang-tidy
-               DOC "Path to clang-tidy executable")
-  if(NOT CLANG_TIDY_EXE)
-      message(STATUS "WARNING: clang-tidy Not found.")
-  else()
-      message(STATUS "{PROJNAME}_ENABLE_CLANG_TIDY = ON: ${CLANG_TIDY_EXE}")
-      set(CMAKE_CXX_CLANG_TIDY
-          "${CLANG_TIDY_EXE}"
-          -header-filter={projname}/)
-  endif()
-else()
-  message(STATUS "{PROJNAME}_ENABLE_CLANG_TIDY = OFF")
+               DOC "Path to clang-tidy executable"
+               REQUIRED)
+  message(STATUS "Found clang-tidy = ${CLANG_TIDY_EXE}")
 endif()
+
+function({projname}_apply_clang_tidy TARGET)
+  message(STATUS "Apply {projname} clang-tidy for ${TARGET}")
+
+  if(MSVC AND CMAKE_GENERATOR MATCHES "Visual Studio")
+    set_target_properties(${TARGET} PROPERTIES
+      VS_GLOBAL_RunCodeAnalysis true
+      VS_GLOBAL_EnableClangTidyCodeAnalysis true
+    )
+  else()
+    set(CLANG_TIDY_COMMAND
+      "${CLANG_TIDY_EXE}"
+      "--quiet"
+      "-p" "'${CMAKE_BINARY_DIR}'"
+    )
+    set_target_properties(${TARGET} PROPERTIES
+      CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}"
+    )
+  endif()
+endfunction()

--- a/scaffolds/cmake_modules/compiler_msvc.cmake
+++ b/scaffolds/cmake_modules/compiler_msvc.cmake
@@ -35,12 +35,9 @@ function({projname}_apply_common_compile_options TARGET)
       /wd4819 # source characters not in current code page.
 
       /Zc:inline            # Have the compiler eliminate unreferenced COMDAT functions and data before emitting the object file.
-      /Zc:referenceBinding  # Disallow temporaries from binding to non-const lvalue references.
       /Zc:rvalueCast        # Enforce the standard rules for explicit type conversion.
-      /Zc:implicitNoexcept  # Enable implicit noexcept specifications where required, such as destructors.
       /Zc:strictStrings     # Don't allow conversion from a string literal to mutable characters.
       /Zc:threadSafeInit    # Enable thread-safe function-local statics initialization.
-      /Zc:throwingNew       # Assume operator new throws on failure.
 
       /permissive-  # Be mean, don't allow bad non-standard stuff (C++/CLI, __declspec, etc. are all left intact).
   )
@@ -69,11 +66,17 @@ function({projname}_apply_msvc_static_analysis TARGET)
   target_compile_options(${TARGET}
     PRIVATE
       /analyze
-      /analyze:WX-
 
       /wd6001 # Using uninitialized memory.
       /wd6011 # Dereferencing potentially NULL pointer.
 
       ${ARG_WDL}
   )
+
+  if (CMAKE_GENERATOR MATCHES "Visual Studio")
+    set_target_properties(${TARGET} PROPERTIES
+      VS_GLOBAL_EnableMicrosoftCodeAnalysis true
+      VS_GLOBAL_RunCodeAnalysis true
+    )
+  endif()
 endfunction()

--- a/scaffolds/tests/CMakeLists.txt
+++ b/scaffolds/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-CPMAddPackage("gh:onqtam/doctest#v2.4.8")
+CPMAddPackage("gh:onqtam/doctest#v2.4.9")
 
 add_executable({projname}_test)
 
@@ -12,22 +12,26 @@ target_link_libraries({projname}_test
     doctest
 )
 
-# {projname}_apply_common_compile_options({projname}_test)
+{projname}_apply_common_compile_options({projname}_test)
 
-# if(MSVC)
-#   get_target_property(test_FILES {projname}_test SOURCES)
-#   source_group("{projname}_test" FILES ${test_FILES})
-#
-#   if({PROJNAME}_USE_MSVC_PARALLEL_BUILD)
-#     {projname}_apply_msvc_parallel_build({projname}_test)
-#   endif()
-#   if({PROJNAME}_USE_MSVC_STATIC_ANALYSIS)
-#     {projname}_apply_msvc_static_analysis({projname}_test)
-#   endif()
-# else()
-#   if({PROJNAME}_USE_SANITIZER)
-#     {projname}_apply_sanitizer({projname}_test)
-#   endif()
-# endif()
+if({PROJNAME}_ENABLE_CLANG_TIDY)
+  {projname}_apply_clang_tidy({projname}_test)
+endif()
+
+if(MSVC)
+  if({PROJNAME}_USE_MSVC_PARALLEL_BUILD)
+    {projname}_apply_msvc_parallel_build({projname}_test)
+  endif()
+  if({PROJNAME}_USE_MSVC_STATIC_ANALYSIS)
+    {projname}_apply_msvc_static_analysis({projname}_test)
+  endif()
+else()
+  if({PROJNAME}_USE_SANITIZER)
+    {projname}_apply_sanitizer({projname}_test)
+  endif()
+endif()
+
+get_target_property(test_FILES {projname}_test SOURCES)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${test_FILES})
 
 add_test(NAME tests COMMAND {projname}_test)


### PR DESCRIPTION
1. Correctly setup clang-tidy for generated msvc projects.
2. Updated CPM.cmake to the latest version.
3. Resolve deprecation use of distutils