### PR TITLE
Some major improvements

### DIFF
--- a/anvil.py
+++ b/anvil.py
@@ -6,7 +6,7 @@ import argparse
 
 import job_init
 
-VER = '0.8.0'
+VER = '0.9.0'
 
 
 def show_anvil_version(_):

--- a/project_rules.toml
+++ b/project_rules.toml
@@ -1,15 +1,20 @@
 
 [cmake]
-    min_ver = "3.19"
+    min_ver = "3.21"
+    use_presets = true
 
 [project]
     name = "Demo"
     cxx_standard = "17"
 
+[package_manager]
+    use_cpm = false
+    use_vcpkg = true
+
 [precompiled_header]
     enabled = true
     # `pch_file` path is relative the current project directory.
-    pch_file = "out/pch/precompile.h"
+    pch_file = "build/pch/precompile.h"
 
 [platform_support]
     windows = true

--- a/scaffolds/CMakeLists.txt.j2
+++ b/scaffolds/CMakeLists.txt.j2
@@ -4,6 +4,7 @@
   - name: project name
   - module_name: main module name
   - cxx_standard: used standard
+  - use_cpm: true/false
   - use_pch: true/false
   - pch_file: relative path to the pch file
   - on_windows: true/false
@@ -42,7 +43,9 @@ set({{ PROJNAME }}_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set({{ PROJNAME }}_CMAKE_DIR ${{ '{' }}{{ PROJNAME }}_DIR}/cmake)
 
 include(CTest)
+{%- if use_cpm %}
 include(${{ '{' }}{{ PROJNAME }}_CMAKE_DIR}/CPM.cmake)
+{%- endif %}
 
 message(STATUS "{{ name }} GENERATOR = " ${CMAKE_GENERATOR})
 

--- a/scaffolds/CMakePresets.json
+++ b/scaffolds/CMakePresets.json
@@ -1,0 +1,25 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+      "major": 3,
+      "minor": 21,
+      "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "linux",
+            "displayName": "Default config on Linux",
+            "description": "Default configuration on Linux",
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/out/${presetName}",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        },
+        {
+            "name": "windows",
+            "displayName": "Default config on Windows",
+            "description": "Default configuration on Windows",
+            "binaryDir": "${sourceDir}/out/${presetName}",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        }
+    ]
+}

--- a/scaffolds/pch/precompile.cpp
+++ b/scaffolds/pch/precompile.cpp
@@ -1,6 +1,6 @@
-/*
- @ 0xCCCCCCCC
-*/
+//
+// 0xCCCCCCCC
+//
 
 // This file is intended to be blank, since it is used as the precompiled header
 // generator for builds. No include in this file is needed as the header include is

--- a/scaffolds/pch/precompile.h
+++ b/scaffolds/pch/precompile.h
@@ -1,6 +1,6 @@
-/*
- @ Kingsley Chen
-*/
+//
+// 0xCCCCCCCC
+//
 
 // Add frequently used header files or remove header files that are less frequently
 // used during project evolvement.

--- a/scaffolds/vcpkg.json.j2
+++ b/scaffolds/vcpkg.json.j2
@@ -1,0 +1,5 @@
+{
+  "name": "{{ projname }}",
+  "version": "0.1.0",
+  "dependencies": []
+}


### PR DESCRIPTION
- cmake minimum required → 3.21
- move pch files into `$PROJECT/build/pch`
-  support vcpkg
- make cpm optional
- support preset (will ignore `build.py` if enabled)